### PR TITLE
Fix #51 - Tests fail on non Linux/Unix platforms

### DIFF
--- a/modules/logging/src/test/kotlin/org/springframework/fu/module/logging/LogbackDslTest.kt
+++ b/modules/logging/src/test/kotlin/org/springframework/fu/module/logging/LogbackDslTest.kt
@@ -34,6 +34,8 @@ import java.io.File
  */
 internal class LogbackDslTest {
 
+	private val tmp = System.getProperty("java.io.tmpdir").let(::File)
+
 	@Test
 	fun `Default Logback Configuration`() {
 		lateinit var logback: LogbackDsl
@@ -104,10 +106,11 @@ internal class LogbackDslTest {
 	fun `Logback rollingFileAppender`() {
 		lateinit var logback: LogbackDsl
 		val context = GenericApplicationContext()
+		val logFile = File(tmp, "log.txt")
 		application {
 			logging {
 				logback = logback {
-					rollingFileAppender(File("/tmp/log.txt"))
+					rollingFileAppender(logFile)
 				}
 			}
 		}.run(context)
@@ -120,7 +123,7 @@ internal class LogbackDslTest {
 			assertTrue(it.isAppend)
 
 			(it.rollingPolicy as SizeAndTimeBasedRollingPolicy<*>).let {
-				assertEquals("/tmp/log.txt", it.activeFileName)
+				assertEquals(logFile.path, it.activeFileName)
 				assertEquals("log.%d{yyyy-MM-dd}.%i.gz", it.fileNamePattern)
 				assertEquals(30, it.maxHistory)
 			}
@@ -131,18 +134,19 @@ internal class LogbackDslTest {
 	fun `Logback rollingFileAppender custom`() {
 		lateinit var logback: LogbackDsl
 		val context = GenericApplicationContext()
+		val logFile = File(tmp, "mylog.txt")
 		application {
 			logging {
 				logback = logback {
 					rollingFileAppender(
-							file = File("/tmp/mylog.txt"),
-							name = "MY_ROLLING",
-							pattern = "%d{yyyy-MM}",
-							fileNamePattern = "%i.gz",
-							maxFileSize = "2GB",
-							maxHistory = 11,
-							totalSizeCap = "1MB",
-							append = false
+						file = logFile,
+						name = "MY_ROLLING",
+						pattern = "%d{yyyy-MM}",
+						fileNamePattern = "%i.gz",
+						maxFileSize = "2GB",
+						maxHistory = 11,
+						totalSizeCap = "1MB",
+						append = false
 					)
 				}
 			}
@@ -158,7 +162,7 @@ internal class LogbackDslTest {
 			assertFalse(it.isAppend)
 
 			(it.rollingPolicy as SizeAndTimeBasedRollingPolicy<*>).let {
-				assertEquals("/tmp/mylog.txt", it.activeFileName)
+				assertEquals(logFile.path, it.activeFileName)
 				assertEquals("%i.gz", it.fileNamePattern)
 				assertEquals(11, it.maxHistory)
 			}

--- a/samples/coroutines-webapp/src/main/kotlin/org/springframework/fu/sample/coroutines/Application.kt
+++ b/samples/coroutines-webapp/src/main/kotlin/org/springframework/fu/sample/coroutines/Application.kt
@@ -49,7 +49,7 @@ val app =  application {
 		logback {
 			debug(true)
 			consoleAppender()
-			rollingFileAppender(File("/tmp/log.txt"))
+			rollingFileAppender(File(System.getProperty("java.io.tmpdir"), "log.txt"))
 		}
 	}
 	webflux {

--- a/samples/reactive-webapp/src/main/kotlin/org/springframework/fu/sample/reactive/Application.kt
+++ b/samples/reactive-webapp/src/main/kotlin/org/springframework/fu/sample/reactive/Application.kt
@@ -43,7 +43,7 @@ val app = application {
 		logback {
 			debug(true)
 			consoleAppender()
-			rollingFileAppender(File("/tmp/log.txt"))
+			rollingFileAppender(File(System.getProperty("java.io.tmpdir"), "log.txt"))
 		}
 	}
 	webflux {


### PR DESCRIPTION
This failure was caused because code assumes specific filesystem layout, which in actuality differs on different platforms and sometimes even within a platform based on security policy.
This PR (hopefully) fixes the problem by introducing platform/policy-independent way to create temporary files needed for tests.
This is my first PR, so I'll be grateful for any feedback and suggestions.
PS: I've signed the CLA