### PR TITLE
gh-11 Improved logging Info for App and WebFlux

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
 	}
 	api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	api("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.slf4j:slf4j-api:1.7.25")
 	testImplementation("org.springframework:spring-test")
 	testImplementation("org.junit.jupiter:junit-jupiter-api")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/modules/webflux/build.gradle.kts
+++ b/modules/webflux/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
 	api(project(":core"))
+	api(project(":modules:logging"))
 	api("org.springframework:spring-webflux")
 }

--- a/modules/webflux/src/main/kotlin/org/springframework/fu/module/webflux/WebFluxModule.kt
+++ b/modules/webflux/src/main/kotlin/org/springframework/fu/module/webflux/WebFluxModule.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.fu.module.webflux
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.context.ApplicationContext
@@ -60,6 +61,7 @@ open class WebFluxModule(private val init: WebFluxModule.() -> Unit): AbstractMo
 	open class WebFluxServerModule(private val init: WebFluxServerModule.() -> Unit,
 							  private val serverModule: WebServerModule): AbstractModule() {
 
+		private val logWebflux = LoggerFactory.getLogger(WebFluxModule::class.java)
 		private val builder = HandlerStrategies.empty()
 
 		override fun initialize(context: GenericApplicationContext) {
@@ -97,6 +99,8 @@ open class WebFluxModule(private val init: WebFluxModule.() -> Unit): AbstractMo
 					else {
 						RouterFunction<ServerResponse> { Mono.empty() }
 					}
+					logWebflux.info("$router")
+
 					RouterFunctions.toWebHandler(router, builder.build())
 				}
 			})


### PR DESCRIPTION
gh #11 

Application startup log : 

`2018-06-12 15:11:12.771  INFO  --- [           main] org.springframework.fu.ApplicationDsl    : Application started in 2.176 seconds (JVM running for 3.145) `

Webflux routes : 

```
2018-06-12 15:11:11.150  INFO  --- [           main] o.s.fu.module.webflux.WebFluxModule      : api => {
 (POST && /foo) -> org.springframework.web.reactive.function.server.RouterFunctionDsl$POST$1@26275bef
}
(POST && /faa) -> org.springframework.web.reactive.function.server.RouterFunctionDsl$POST$1@7690781
(GET && /foo) -> org.springframework.web.reactive.function.server.RouterFunctionDsl$GET$1@77eca502
(GET && /bar) -> org.springframework.web.reactive.function.server.RouterFunctionDsl$GET$1@3246fb96 
```

