### PR TITLE
Update Getting started code sample to match working samples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,8 +126,9 @@ val app = application {
 		}	
 	}
 }
-
-fun main() = app.run()
+fun main() {
+	app.run()
+}
 ```
 
 === Samples


### PR DESCRIPTION
This PR will update the Readme sample to reflect the change of `ApplicationDsl`'s `run` method that is now returning `ConfigurableApplicationContext` and is no longer possible to use it in a single expression `main` method.