### PR TITLE
Remove double-definition

### DIFF
--- a/samples/kofu-reactive-minimal/graal/app.json
+++ b/samples/kofu-reactive-minimal/graal/app.json
@@ -6,12 +6,6 @@
     "allDeclaredMethods": true
   },
   {
-    "name": "[Lcom.sample.SampleService;",
-    "allPublicConstructors" : true,
-    "allDeclaredConstructors" : true,
-    "allDeclaredMethods": true
-  },
-  {
     "name": "com.sample.SampleHandler",
     "allDeclaredConstructors" : true,
     "allDeclaredMethods": true


### PR DESCRIPTION
There seems to be a double-definition of the Servlet-Mapping for the Binary for GraalVM int the kofu-reactive-minimal sample.