### PR TITLE
URL Cleanup

### DIFF
--- a/samples/jafu-reactive-minimal/build.gradle.kts
+++ b/samples/jafu-reactive-minimal/build.gradle.kts
@@ -23,5 +23,5 @@ repositories {
 	mavenCentral()
 	maven("https://repo.spring.io/milestone")
 	maven("https://repo.spring.io/snapshot")
-	maven("http://dl.bintray.com/kotlin/kotlin-eap")
+	maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dl.bintray.com/kotlin/kotlin-eap with 1 occurrences migrated to:  
  https://dl.bintray.com/kotlin/kotlin-eap ([https](https://dl.bintray.com/kotlin/kotlin-eap) result 301).