### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/SpringFuApplication.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/SpringFuApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoDataInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoReactiveDataInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/data/mongo/MongoReactiveDataInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonJsonCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonJsonCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/coroutines/CoroutinesMongoInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/coroutines/CoroutinesMongoInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mongo/embedded/EmbeddedMongoInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/mustache/MustacheReactiveWebInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/FormCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/FormCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/MultipartCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/MultipartCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ProtobufCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ProtobufCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ReactiveWebServerInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ReactiveWebServerInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ResourceCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ResourceCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/StringCodecInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/StringCodecInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactiveWebClientBuilderInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactiveWebClientBuilderInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/context/config/FunctionalConfigFileApplicationListener.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/context/config/FunctionalConfigFileApplicationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/context/properties/FunctionalConfigurationPropertiesBinder.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/context/properties/FunctionalConfigurationPropertiesBinder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/diagnostics/analyzer/FunctionalFailureAnalyzers.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/diagnostics/analyzer/FunctionalFailureAnalyzers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoCollectionCallback.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoCollectionCallback.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoDatabaseCallback.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoDatabaseCallback.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoCollection.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoCollection.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoOperations.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoOperations.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoTemplate.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoTemplate.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoTemplateExtensions.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoTemplateExtensions.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/index/CoIndexOperations.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/index/CoIndexOperations.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/index/DefaultCoIndexOperations.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/index/DefaultCoIndexOperations.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/CoHttpInputMessage.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/CoHttpInputMessage.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/CoHttpOutputMessage.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/CoHttpOutputMessage.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/codec/CoHttpMessageReader.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/codec/CoHttpMessageReader.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/server/CoServerHttpResponse.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/server/CoServerHttpResponse.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/server/coroutines/CoServerHttpRequest.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/server/coroutines/CoServerHttpRequest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/http/server/coroutines/DefaultCoServerHttpRequest.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/http/server/coroutines/DefaultCoServerHttpRequest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyExtractor.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyExtractor.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyExtractors.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyExtractors.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyInserter.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/CoBodyInserter.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/client/CoClientResponse.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/client/CoClientResponse.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/client/CoWebClient.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/client/CoWebClient.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoRenderingResponse.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoRenderingResponse.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoRouterFunction.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoRouterFunction.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoServerRequest.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoServerRequest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoServerResponse.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/function/server/CoServerResponse.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoServerWebExchange.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoServerWebExchange.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebFilter.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebFilter.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebFilterChain.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebFilterChain.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebSession.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/CoWebSession.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/DefaultCoServerWebExchange.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/DefaultCoServerWebExchange.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/coroutines/webflux/src/main/kotlin/org/springframework/web/server/session/DefaultCoWebSession.kt
+++ b/coroutines/webflux/src/main/kotlin/org/springframework/web/server/session/DefaultCoWebSession.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jafu/src/test/java/org/springframework/fu/jafu/web/WebServerDslTests.java
+++ b/jafu/src/test/java/org/springframework/fu/jafu/web/WebServerDslTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/AbstractDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/AbstractDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/ApplicationDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/ApplicationDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/LoggingDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/LoggingDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/mongo/MongoDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/mongo/MongoDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/web/JacksonDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/web/JacksonDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/web/MustacheDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/web/MustacheDsl.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/ApplicationDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/ApplicationDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/LoggingDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/LoggingDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/mongo/EmbeddedMongoDslTest.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/mongo/EmbeddedMongoDslTest.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/application.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/application.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/web/CorsDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/web/CorsDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/web/JacksonDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/web/JacksonDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/web/MustacheDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/web/MustacheDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/web/WebServerDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/web/WebServerDslTests.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/kofu-coroutines-r2dbc/src/main/kotlin/com/sample/Application.kt
+++ b/samples/kofu-coroutines-r2dbc/src/main/kotlin/com/sample/Application.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/kofu-reactive-mongodb/src/main/kotlin/com/sample/Application.kt
+++ b/samples/kofu-reactive-mongodb/src/main/kotlin/com/sample/Application.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/kofu-reactive-r2dbc/src/main/kotlin/com/sample/Application.kt
+++ b/samples/kofu-reactive-r2dbc/src/main/kotlin/com/sample/Application.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 69 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).