### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -22,4 +22,4 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at spring-code-of-conduct@pivotal.io . All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ image::https://ci.spring.io/api/v1/teams/spring-fu/pipelines/spring-fu/badge["Bu
 Spring Fu is an incubator for new Spring features related to functional configuration and runtime efficiency.
 
 Instead of using JavaConfig and auto-configuration, it provides an explicit way of configuring Spring Boot applications
-with a http://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html[Kotlin DSL (Kofu)]
+with a https://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html[Kotlin DSL (Kofu)]
 or a https://github.com/spring-projects/spring-fu/tree/master/jafu[Java DSL (Jafu)] and lambdas
 using functional bean definitions for both Spring Boot infrastructure and application code.
 

--- a/ROADMAP.adoc
+++ b/ROADMAP.adoc
@@ -4,7 +4,7 @@
 a|**Feature** |**Status** |**Related issue**
 
 a|
-http://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html[Kofu] and
+https://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html[Kofu] and
 https://github.com/spring-projects/spring-fu/tree/master/jafu[Jafu] configuration DSL
 a|
 Incubating in Spring Fu

--- a/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoOperations.kt
+++ b/coroutines/data-mongodb/src/main/kotlin/org/springframework/data/mongodb/core/CoMongoOperations.kt
@@ -615,7 +615,7 @@ interface CoMongoOperations {
      * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
      * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
      * [
- * Spring's Type Conversion"](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
+ * Spring's Type Conversion"](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
      *
      *
      *
@@ -681,7 +681,7 @@ interface CoMongoOperations {
      * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
      * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
      * [
- * Spring's Type Conversion"](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
+ * Spring's Type Conversion"](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
      *
      *
      *
@@ -733,7 +733,7 @@ interface CoMongoOperations {
      * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
      * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
      * [
- * Spring's Type Conversion"](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
+ * Spring's Type Conversion"](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
      *
      * @param objectToSave the object to store in the collection
      * @return
@@ -773,7 +773,7 @@ interface CoMongoOperations {
      * String then MongoDB ObjectId will be used to populate that string. Otherwise, the conversion from ObjectId to your
      * property type will be handled by Spring's BeanWrapper class that leverages Type Conversion API. See
      * [
- * Spring's Type Conversion"](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
+ * Spring's Type Conversion"](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html#core-convert) for more details.
      *
      * @param objectToSave the object to store in the collection
      * @return

--- a/jafu/src/test/java/org/springframework/fu/jafu/web/MustacheDslTests.java
+++ b/jafu/src/test/java/org/springframework/fu/jafu/web/MustacheDslTests.java
@@ -21,7 +21,7 @@ public class MustacheDslTests {
 		var app = application(a -> a.enable(WebFluxServerDsl.class, s -> s.mustache().importRouter(router)));
 
 		var context = app.run();
-		var client = WebTestClient.bindToServer().baseUrl("http://0.0.0.0:8080").build();
+		var client = WebTestClient.bindToServer().baseUrl("https://0.0.0.0:8080").build();
 		client.get().uri("/view").exchange()
 				.expectStatus().is2xxSuccessful()
 				.expectBody(String.class)

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsConfigurationDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsConfigurationDsl.kt
@@ -29,7 +29,7 @@ class CorsConfigurationDsl(defaults: Boolean = true,
 	}
 
 	/**
-	 * Set the origins to allow, separated by commas, e.g. `http://domain1.com, http://domain2.com`. The special value `*` allows all domains.
+	 * Set the origins to allow, separated by commas, e.g. `https://domain1.com, https://domain2.com`. The special value `*` allows all domains.
 	 * By default, all origins are allowed.
 	 */
 	var allowedOrigins: String = "*"
@@ -41,7 +41,7 @@ class CorsConfigurationDsl(defaults: Boolean = true,
 	 * Set the HTTP methods to allow,  separated by commas, e.g. `GET, POST, PUT`. The special value `*` allows all methods.
 	 * If not set, only `GET` and `HEAD` are allowed. By default, allow "simple" methods `GET`, `HEAD` and `POST`.
 	 *
-	 * Note: CORS checks use values from `Forwarded` ([RFC 7239](http://tools.ietf.org/html/rfc7239),
+	 * Note: CORS checks use values from `Forwarded` ([RFC 7239](https://tools.ietf.org/html/rfc7239),
 	 * `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Proto` headers if present, in order
 	 * to reflect the client-originated address.
 	 */

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/web/MustacheDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/web/MustacheDslTests.kt
@@ -40,7 +40,7 @@ class MustacheDslTests {
 			}
 		}
 		val context = app.run()
-		val client = WebTestClient.bindToServer().baseUrl("http://0.0.0.0:8080").build()
+		val client = WebTestClient.bindToServer().baseUrl("https://0.0.0.0:8080").build()
 		client.get().uri("/view").exchange()
 			.expectStatus().is2xxSuccessful
 			.expectBody<String>()


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://0.0.0.0:8080 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://0.0.0.0:8080 ([https](https://0.0.0.0:8080) result AnnotatedConnectException).
* [ ] http://domain1.com (UnknownHostException) with 1 occurrences migrated to:  
  https://domain1.com ([https](https://domain1.com) result UnknownHostException).
* [ ] http://domain2.com (UnknownHostException) with 1 occurrences migrated to:  
  https://domain2.com ([https](https://domain2.com) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html ([https](https://repo.spring.io/snapshot/org/springframework/fu/spring-fu-kofu/0.0.3.BUILD-SNAPSHOT/spring-fu-kofu-0.0.3.BUILD-SNAPSHOT-javadoc.jar!/kofu/org.springframework.fu.kofu/application.html) result 200).
* [ ] http://tools.ietf.org/html/rfc7239 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7239 ([https](https://tools.ietf.org/html/rfc7239) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/validation.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 8 occurrences
* http://127.0.0.1:8080 with 5 occurrences
* http://127.0.0.1:8080/user with 2 occurrences
* http://localhost:8080 with 2 occurrences
* http://localhost:8080/ with 4 occurrences
* http://localhost:8181 with 7 occurrences