### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -22,4 +22,4 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at spring-code-of-conduct@pivotal.io . All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/jafu/README.adoc
+++ b/jafu/README.adoc
@@ -1,5 +1,5 @@
 :spring-fu-version: 0.0.5
-:jafu-javadoc-url: http://repo.spring.io/milestone/org/springframework/fu/spring-fu-jafu/{spring-fu-version}/spring-fu-jafu-{spring-fu-version}-javadoc.jar!
+:jafu-javadoc-url: https://repo.spring.io/milestone/org/springframework/fu/spring-fu-jafu/{spring-fu-version}/spring-fu-jafu-{spring-fu-version}-javadoc.jar!
 :framework-javadoc-url: https://docs.spring.io/spring-framework/docs/5.1.x/javadoc-api
 = Jafu DSL for Spring Boot
 
@@ -114,7 +114,7 @@ public class DemoApplication {
 === jafu-reactive-minimal
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/jafu-reactive-minimal[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-minimal/{spring-fu-version}/spring-fu-samples-jafu-reactive-minimal-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-minimal/{spring-fu-version}/spring-fu-samples-jafu-reactive-minimal-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Reactive web application with Jafu configuration which provides a
 `http://localhost:8080/` endpoint that displays "Hello world!" and an `http://localhost:8080/api` with a JSON
@@ -126,6 +126,6 @@ You can run compile and run it as a https://github.com/oracle/graal/tree/master/
 === jafu-reactive-r2dbc
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/jafu-reactive-r2dbc[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-r2dbc/{spring-fu-version}/spring-fu-samples-jafu-reactive-r2dbc-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-r2dbc/{spring-fu-version}/spring-fu-samples-jafu-reactive-r2dbc-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Reactive web application with Jafu configuration and a R2DBC backend.

--- a/jafu/src/main/java/org/springframework/fu/jafu/r2dbc/H2R2dbcDsl.java
+++ b/jafu/src/main/java/org/springframework/fu/jafu/r2dbc/H2R2dbcDsl.java
@@ -50,7 +50,7 @@ public class H2R2dbcDsl extends AbstractDsl {
 	 * Includes everything after the {@code jdbc:h2:} prefix.
 	 * For in-memory and file-based databases, must include the proper prefix (e.g. {@code file:} or {@code mem:}).
 	 *
-	 * See <a href="http://www.h2database.com/html/features.html#database_url">http://www.h2database.com/html/features.html#database_url</a> for more details.
+	 * See <a href="https://www.h2database.com/html/features.html#database_url">https://www.h2database.com/html/features.html#database_url</a> for more details.
 	 */
 	public H2R2dbcDsl url(String url) {
 		properties.setUrl(url);

--- a/kofu/README.adoc
+++ b/kofu/README.adoc
@@ -1,5 +1,5 @@
 :spring-fu-version: 0.0.5
-:kofu-kdoc-url: http://repo.spring.io/milestone/org/springframework/fu/spring-fu-kofu/{spring-fu-version}/spring-fu-kofu-{spring-fu-version}-javadoc.jar!
+:kofu-kdoc-url: https://repo.spring.io/milestone/org/springframework/fu/spring-fu-kofu/{spring-fu-version}/spring-fu-kofu-{spring-fu-version}-javadoc.jar!
 :framework-kdoc-url: https://docs.spring.io/spring-framework/docs/5.1.x/kdoc-api
 = Kofu DSL for Spring Boot
 
@@ -109,7 +109,7 @@ fun main() {
 === kofu-reactive-minimal
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/kofu-reactive-minimal[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-minimal/{spring-fu-version}/spring-fu-samples-kofu-reactive-minimal-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-minimal/{spring-fu-version}/spring-fu-samples-kofu-reactive-minimal-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Reactive web application with Kofu configuration which provides a
 `http://localhost:8080/` endpoint that displays "Hello world!" and an `http://localhost:8080/api` with a JSON
@@ -121,27 +121,27 @@ You can run compile and run it as a https://github.com/oracle/graal/tree/master/
 === kofu-reactive-mongodb
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/kofu-reactive-mongodb[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-mongodb/{spring-fu-version}/spring-fu-samples-kofu-reactive-mongodb-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-mongodb/{spring-fu-version}/spring-fu-samples-kofu-reactive-mongodb-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Reactive web application with Kofu configuration and a Reactive MongoDB backend.
 
 === kofu-reactive-r2dbc
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/kofu-reactive-r2dbc[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-r2dbc/{spring-fu-version}/spring-fu-samples-kofu-reactive-r2dbc-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-r2dbc/{spring-fu-version}/spring-fu-samples-kofu-reactive-r2dbc-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Reactive web application with Kofu configuration and a R2DBC backend.
 
 === kofu-coroutines-mongodb
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/kofu-coroutines-mongodb[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-mongodb/{spring-fu-version}/spring-fu-samples-kofu-coroutines-mongodb-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-mongodb/{spring-fu-version}/spring-fu-samples-kofu-coroutines-mongodb-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Coroutines web application with Kofu configuration and a Reactive MongoDB backend.
 
 === kofu-coroutines-r2dbc
 
 https://github.com/spring-projects/spring-fu/tree/master/samples/kofu-coroutines-r2dbc[Browse source] |
-http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-r2dbc/{spring-fu-version}/spring-fu-samples-kofu-coroutines-r2dbc-{spring-fu-version}.zip[Download]
+https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-r2dbc/{spring-fu-version}/spring-fu-samples-kofu-coroutines-r2dbc-{spring-fu-version}.zip[Download]
 
 This is a sample project for a Spring Boot Coroutines web application with Kofu configuration and a R2DBC backend.

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/r2dbc/H2R2dbcDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/r2dbc/H2R2dbcDsl.kt
@@ -23,7 +23,7 @@ class H2R2dbcDsl(private val init: H2R2dbcDsl.() -> Unit) : AbstractDsl() {
      * Includes everything after the `jdbc:h2:` prefix.
      * For in-memory and file-based databases, must include the proper prefix (e.g. `file:` or `mem:`).
      *
-     * See [http://www.h2database.com/html/features.html#database_url](http://www.h2database.com/html/features.html#database_url) for more details.
+     * See [https://www.h2database.com/html/features.html#database_url](https://www.h2database.com/html/features.html#database_url) for more details.
      */
     var url: String = "mem:test;DB_CLOSE_DELAY=-1"
 

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/web/CorsDsl.kt
@@ -66,7 +66,7 @@ class CorsDsl(
 		}
 
 		/**
-		 * Set the origins to allow, separated by commas, e.g. `http://domain1.com, http://domain2.com`. The special value `*` allows all domains.
+		 * Set the origins to allow, separated by commas, e.g. `https://domain1.com, https://domain2.com`. The special value `*` allows all domains.
 		 * By default, all origins are allowed.
 		 */
 		var allowedOrigins: String = "*"
@@ -78,7 +78,7 @@ class CorsDsl(
 		 * Set the HTTP methods to allow,  separated by commas, e.g. `GET, POST, PUT`. The special value `*` allows all methods.
 		 * If not set, only `GET` and `HEAD` are allowed. By default, allow "simple" methods `GET`, `HEAD` and `POST`.
 		 *
-		 * Note: CORS checks use values from `Forwarded` ([RFC 7239](http://tools.ietf.org/html/rfc7239),
+		 * Note: CORS checks use values from `Forwarded` ([RFC 7239](https://tools.ietf.org/html/rfc7239),
 		 * `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Proto` headers if present, in order
 		 * to reflect the client-originated address.
 		 */


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://domain1.com (UnknownHostException) with 1 occurrences migrated to:  
  https://domain1.com ([https](https://domain1.com) result UnknownHostException).
* [ ] http://domain2.com (UnknownHostException) with 1 occurrences migrated to:  
  https://domain2.com ([https](https://domain2.com) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-jafu/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-jafu/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-jafu/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-kofu/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-kofu/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-kofu/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-minimal/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-minimal/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-minimal/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-r2dbc/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-r2dbc/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-jafu-reactive-r2dbc/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-mongodb/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-mongodb/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-mongodb/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-r2dbc/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-r2dbc/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-coroutines-r2dbc/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-minimal/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-minimal/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-minimal/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-mongodb/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-mongodb/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-mongodb/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-r2dbc/ with 1 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-r2dbc/ ([https](https://repo.spring.io/milestone/org/springframework/fu/spring-fu-samples-kofu-reactive-r2dbc/) result 200).
* [ ] http://tools.ietf.org/html/rfc7239 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7239 ([https](https://tools.ietf.org/html/rfc7239) result 200).
* [ ] http://www.h2database.com/html/features.html with 4 occurrences migrated to:  
  https://www.h2database.com/html/features.html ([https](https://www.h2database.com/html/features.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 21 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/api with 2 occurrences
* http://localhost:8181 with 7 occurrences