### PR TITLE
Updated download links on samples README page

### DIFF
--- a/samples/README.adoc
+++ b/samples/README.adoc
@@ -1,3 +1,4 @@
+:spring-fu-version: 0.1.BUILD-SNAPSHOT
 == Samples
 
 === kofu-reactive-minimal


### PR DESCRIPTION
The download links were broken on the samples page because the spring-fu-version attribute in the top level README file was not being read.  I am not sure if there is a way to achieve this on Github.  Although this solution is not ideal, I propose adding a separate attribute for the spring-fu-version on the samples page so that the download links are functional.